### PR TITLE
Added user issue form for mandatory Player.log uploads

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,20 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Website
+    url: https://play.eco/
+    about: Visit our website for more information and contact options.
+  - name: Facebook
+    url: https://www.facebook.com/EcoVideoGame
+    about: Follow us on Facebook.
+  - name: Twitter
+    url: https://twitter.com/StrangeLoopGame
+    about: Follow us on Twitter.
+  - name: Steam
+    url: https://store.steampowered.com/app/382310/Eco/
+    about: Buy the game on Steam.
+  - name: YouTube
+    url: https://www.youtube.com/user/StrangeLoopGame
+    about: Subscribe to us on YouTube.
+  - name: Discord
+    url: https://discord.gg/eco
+    about: Join the community on our Discord server.

--- a/.github/ISSUE_TEMPLATE/user_issue.yml
+++ b/.github/ISSUE_TEMPLATE/user_issue.yml
@@ -1,0 +1,69 @@
+name: User Issue
+description: Submit an issue for Eco, the game
+title: "USER ISSUE: "
+body:
+  - type: input
+    id: eco_user_id
+    attributes:
+      label: "User Id:"
+    validations:
+      required: false
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: "Steps to Reproduce:"
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: "Expected behavior:"
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: "Actual behavior:"
+    validations:
+      required: true
+  - type: textarea
+    id: mods
+    attributes:
+      label: "Do you have mods installed? Does the issue happen when no mods are installed?"
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: "Please provide log files:"
+      description: |
+        Please select your operating system for instructions:
+
+        <details><summary>Windows (32 or 64 bit)</summary>
+
+        1. Open a windows explorer window (Win+E).
+        2. Search for 'run' in the system search, open the program, type `%LOCALAPPDATA%Low/Strange Loop Games/Eco` into it and press enter.
+        3. Click in the text box below.
+        4. Drag "Player.log" and "Player-prev.log" into this text box.
+        </details>
+
+        <details><summary>Linux</summary>
+
+        1. Locate the log file at `~/.config/unity3d/Strange Loop Games/Eco/Player.log`
+        2. Click in the text box below.
+        3. Drag "Player.log" and "Player-prev.log" into this text box.
+        </details>
+
+        <details><summary>Mac</summary>
+
+        1. Locate the log file at `~/Library/Logs/Strange Loop Games/Eco/Player.log`
+        2. Click in the text box below.
+        3. Drag "Player.log" and "Player-prev.log" into this text box.
+        </details>
+
+        **Please click in the text box below and drag your `Player.log` file in the text box.**
+    validations:
+      required: true


### PR DESCRIPTION
This PR adds the new [GitHub issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms) to the EcoIssues repository so people don't forget to upload the `Player.log` file. It also adds inline instructions for fetching those logs. **Feel free to ignore/close if it doesn't help.**

## User experience

If a user tries to open an issue from GitHub they will be confronted with the following screen:

![](https://user-images.githubusercontent.com/86970079/128626540-c6042154-ec6e-4963-9832-9128938a1be8.png)

Both users from the game and from GitHub will then see the following screen:

![](https://user-images.githubusercontent.com/86970079/128626558-34980c98-4e89-42ca-a629-9a37b6b20c93.png)

This screen will force users to add text to the player logs field. (This can be disabled by editing [.github/ISSUE_TEMPLATE/user_issue.yml](.github/ISSUE_TEMPLATE/user_issue.yml) and changing the `required` validation to `false`.

## Bug report form changes

In order to make use of the new issue forms, the Eco game needs to be modified slightly. Instead of submitting `body` field with the entire text, the following fields should be submitted separately in the URL:

- `eco_user_id`
- `reproduce`
- `expected`
- `actual`
- `mods`
- `logs`

The original method **still works** because the [confg.yml](.github/ISSUE_TEMPLATE/config.yml) file contains the `blank_issues_enabled` setting allowing blank issues to be submitted. Older game versions will submit plain text issues.
